### PR TITLE
fix(repo-name): fix whole repo structure for releasing with the new name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ npm-debug.log
 
 coverage/
 
-get-function-name.js
+get-func-name.js

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <h1 align=center>
   <a href="http://chaijs.com" title="Chai Documentation">
-    <img alt="ChaiJS" src="http://chaijs.com/img/chai-logo.png"/> get-function-name
+    <img alt="ChaiJS" src="http://chaijs.com/img/chai-logo.png"/> get-func-name
   </a>
 </h1>
 
@@ -15,47 +15,47 @@
       src="https://img.shields.io/badge/license-mit-green.svg?style=flat-square"
     />
   </a>
-  <a href="https://github.com/chaijs/get-function-name/releases">
+  <a href="https://github.com/chaijs/get-func-name/releases">
     <img
       alt="tag:?"
-      src="https://img.shields.io/github/tag/chaijs/get-function-name.svg?style=flat-square"
+      src="https://img.shields.io/github/tag/chaijs/get-func-name.svg?style=flat-square"
     />
   </a>
-  <a href="https://travis-ci.org/chaijs/get-function-name">
+  <a href="https://travis-ci.org/chaijs/get-func-name">
     <img
       alt="build:?"
-      src="https://img.shields.io/travis/chaijs/get-function-name/master.svg?style=flat-square"
+      src="https://img.shields.io/travis/chaijs/get-func-name/master.svg?style=flat-square"
     />
   </a>
-  <a href="https://coveralls.io/r/chaijs/get-function-name">
+  <a href="https://coveralls.io/r/chaijs/get-func-name">
     <img
       alt="coverage:?"
-      src="https://img.shields.io/coveralls/chaijs/get-function-name/master.svg?style=flat-square"
+      src="https://img.shields.io/coveralls/chaijs/get-func-name/master.svg?style=flat-square"
     />
   </a>
-  <a href="https://www.npmjs.com/packages/get-function-name">
+  <a href="https://www.npmjs.com/packages/get-func-name">
     <img
       alt="npm:?"
-      src="https://img.shields.io/npm/v/get-function-name.svg?style=flat-square"
+      src="https://img.shields.io/npm/v/get-func-name.svg?style=flat-square"
     />
   </a>
-  <a href="https://www.npmjs.com/packages/get-function-name">
+  <a href="https://www.npmjs.com/packages/get-func-name">
     <img
       alt="dependencies:?"
-      src="https://img.shields.io/npm/dm/get-function-name.svg?style=flat-square"
+      src="https://img.shields.io/npm/dm/get-func-name.svg?style=flat-square"
     />
   </a>
   <a href="">
     <img
       alt="devDependencies:?"
-      src="https://img.shields.io/david/chaijs/get-function-name.svg?style=flat-square"
+      src="https://img.shields.io/david/chaijs/get-func-name.svg?style=flat-square"
     />
   </a>
   <br/>
-  <a href="https://saucelabs.com/u/chaijs-get-function-name">
+  <a href="https://saucelabs.com/u/chaijs-get-func-name">
     <img
       alt="Selenium Test Status"
-      src="https://saucelabs.com/browser-matrix/chaijs-get-function-name.svg"
+      src="https://saucelabs.com/browser-matrix/chaijs-get-func-name.svg"
     />
   </a>
   <br>
@@ -73,7 +73,7 @@
   </a>
 </p>
 
-## What is get-function-name?
+## What is get-func-name?
 
 This is a module to retrieve a function's name securely and consistently both in NodeJS and the browser.
 
@@ -81,32 +81,32 @@ This is a module to retrieve a function's name securely and consistently both in
 
 ### Node.js
 
-`get-function-name` is available on [npm](http://npmjs.org). To install it, type:
+`get-func-name` is available on [npm](http://npmjs.org). To install it, type:
 
-    $ npm install get-function-name
+    $ npm install get-func-name
 
 ### Browsers
 
-You can also use it within the browser; install via npm and use the `get-function-name.js` file found within the download. For example:
+You can also use it within the browser; install via npm and use the `get-func-name.js` file found within the download. For example:
 
 ```html
-<script src="./node_modules/get-function-name/get-function-name.js"></script>
+<script src="./node_modules/get-func-name/get-func-name.js"></script>
 ```
 
 ## Usage
 
-The module `get-function-name` exports the following method:
+The module `get-func-name` exports the following method:
 
-* `getFunctionName(fn)` - Returns the name of a function.
+* `getFuncName(fn)` - Returns the name of a function.
 
 ```js
-var getFunctionName = require('get-function-name');
+var getFuncName = require('get-func-name');
 ```
 
-#### .getFunctionName(fun)
+#### .getFuncName(fun)
 
 ```js
-var getFunctionName = require('get-function-name');
+var getFuncName = require('get-func-name');
 
 var unknownFunction = function myCoolFunction(word) {
    return word + 'is cool'; 
@@ -116,6 +116,6 @@ var anonymousFunction = (function () {
     return function () {};
 }());
 
-getFunctionName(unknownFunction) // 'myCoolFunction'
-getFunctionName(anonymousFunction) // ''
+getFuncName(unknownFunction) // 'myCoolFunction'
+getFuncName(anonymousFunction) // ''
 ```

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 'use strict';
 
 /* !
- * Chai - getFunctionName utility
+ * Chai - getFuncName utility
  * Copyright(c) 2012-2016 Jake Luer <jake@alogicalparadox.com>
  * MIT Licensed
  */
 
 /**
- * ### .getFunctionName(constructorFn)
+ * ### .getFuncName(constructorFn)
  *
  * Returns the name of a function.
  * This also includes a polyfill function if `aFunc.name` is not defined.
  *
- * @name getFunctionName
+ * @name getFuncName
  * @param {Function} funct
  * @namespace Utils
  * @api public
@@ -20,7 +20,7 @@
 
 var toString = Function.prototype.toString;
 var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
-function getFunctionName(aFunc) {
+function getFuncName(aFunc) {
   var name = '';
   if (typeof Function.prototype.name === 'undefined' && typeof aFunc.name === 'undefined') {
     // Here we run a polyfill if Function does not support the `name` property and if aFunc.name is not defined
@@ -36,4 +36,4 @@ function getFunctionName(aFunc) {
   return name;
 }
 
-module.exports = getFunctionName;
+module.exports = getFuncName;

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -86,7 +86,7 @@ module.exports = function configureKarma(config) {
         recordVideo: true,
         startConnect: ('TRAVIS' in process.env) === false,
         tags: [
-          'getFunctionName_' + packageJson.version,
+          'getFuncName_' + packageJson.version,
           process.env.SAUCE_USERNAME + '@' + branch,
           build,
         ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "get-func-name",
   "description": "Utility for getting a function's name for node and the browser",
   "keywords": [
-    "get-function-name",
+    "get-func-name",
     "chai util"
   ],
   "license": "MIT",
@@ -16,15 +16,15 @@
   ],
   "files": [
     "index.js",
-    "get-function-name.js"
+    "get-func-name.js"
   ],
   "main": "./index.js",
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/chaijs/get-function-name.git"
+    "url": "git+ssh://git@github.com/chaijs/get-func-name.git"
   },
   "scripts": {
-    "build": "browserify --bare $npm_package_main --standalone getFunctionName -o get-function-name.js",
+    "build": "browserify --bare $npm_package_main --standalone getFuncName -o get-func-name.js",
     "lint": "eslint --ignore-path .gitignore .",
     "prepublish": "npm run build",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,9 @@
 'use strict';
 var assert = require('simple-assert');
-var getFunctionName = require('..');
-describe('getFunctionName', function () {
-  it('getFunctionName', function () {
-    // Asserting that `getFunctionName` behaves correctly
+var getFuncName = require('..');
+describe('getFuncName', function () {
+  it('getFuncName', function () {
+    // Asserting that `getFuncName` behaves correctly
     function /*one*/correctName/*two*/() { // eslint-disable-line no-inline-comments, spaced-comment
       return 0;
     }
@@ -16,8 +16,8 @@ describe('getFunctionName', function () {
         return 2;
       };
     }());
-    assert(getFunctionName(correctName) === 'correctName');
-    assert(getFunctionName(withoutComments) === 'withoutComments');
-    assert(getFunctionName(anonymousFunc) === '');
+    assert(getFuncName(correctName) === 'correctName');
+    assert(getFuncName(withoutComments) === 'withoutComments');
+    assert(getFuncName(anonymousFunc) === '');
   });
 });


### PR DESCRIPTION
This fixes the whole repo structure including the name of built files, tests and docs.
Please only merge this after renaming this repo to `get-func-name` in order to keep things consistent.