### PR TITLE
fix(dependencies): add watchify as a dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "semantic-release": "^4.3.5",
     "simple-assert": "^1.0.0",
     "travis-after-all": "^1.4.4",
-    "validate-commit-msg": "^2.3.1"
+    "validate-commit-msg": "^2.3.1",
+    "watchify": "^3.7.0"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
Hello everyone!

I'm getting this warning when running `npm install` in a fresh clone of `get-func-name`

```bash
└── UNMET PEER DEPENDENCY watchify@>=3 <4

npm WARN karma-browserify@5.1.0 requires a peer of watchify@>=3 <4 but none was installed.
lucas at kabutops on ~/dev/get-func-name [master] ✔
↪ npm --version
3.10.3
lucas at kabutops on ~/dev/get-func-name [master] ✔
↪ node --version
v6.6.0
```

So this PR adds watchify to dev-dependencies to fix the warning.

Thanks 😄 