### PR TITLE
chore: fix eslint dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "coveralls": "2.11.14",
-    "eslint": "^3.7.1",
+    "eslint": "^2.4.0",
     "eslint-config-strict": "^9.1.0",
     "eslint-plugin-filenames": "^1.1.0",
     "ghooks": "^1.0.1",


### PR DESCRIPTION
This fixes the version of `eslint` which broke our build on old node versions.
I'm not sure how did this happen because the checks were passing and we were able to merge that PR, but travis is now failing.
Let's update this again when we don't need to support v0.10 and v0.12 anymore.

Let me know if I missed something.