### PR TITLE
Return null when passed a non-function argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@
  * ### .getFuncName(constructorFn)
  *
  * Returns the name of a function.
+ * When a non-function instance is passed, returns `null`.
  * This also includes a polyfill function if `aFunc.name` is not defined.
  *
  * @name getFuncName
@@ -21,6 +22,10 @@
 var toString = Function.prototype.toString;
 var functionNameMatch = /\s*function(?:\s|\s*\/\*[^(?:*\/)]+\*\/\s*)*([^\s\(\/]+)/;
 function getFuncName(aFunc) {
+  if (typeof aFunc !== 'function') {
+    return null;
+  }
+
   var name = '';
   if (typeof Function.prototype.name === 'undefined' && typeof aFunc.name === 'undefined') {
     // Here we run a polyfill if Function does not support the `name` property and if aFunc.name is not defined

--- a/test/index.js
+++ b/test/index.js
@@ -26,5 +26,35 @@ describe('getFuncName', function () {
     }());
     assert(getFuncName(anonymousFunc) === '');
   });
+
+  it('should return `null` when passed a String as argument', function () {
+    assert(getFuncName('') === null);
+  });
+
+  it('should return `null` when passed a Number as argument', function () {
+    assert(getFuncName(1) === null);
+  });
+
+  it('should return `null` when passed a Boolean as argument', function () {
+    assert(getFuncName(true) === null);
+  });
+
+  it('should return `null` when passed `null` as argument', function () {
+    assert(getFuncName(null) === null);
+  });
+
+  it('should return `null` when passed `undefined` as argument', function () {
+    assert(getFuncName(undefined) === null);
+  });
+
+  it('should return `null` when passed a Symbol as argument', function () {
+    if (typeof Symbol !== 'undefined') {
+      assert(getFuncName(Symbol()) === null);
+    }
+  });
+
+  it('should return `null` when passed an Object as argument', function () {
+    assert(getFuncName({}) === null);
+  });
 });
 


### PR DESCRIPTION
This PR aims to solve the issue described at chaijs/chai#893.

I just added a simple `instanceof` check to the main function in this module in order to detect when something that is not an instance of a function is passed. When that happens we return `null`.

Also, this should be enough to cover all cases since the `@@hasInstance` symbol needs to be implemented on the "father" functions in order for it to recognize other instances as their children, so if anyone implemented `@@hasInstance` on the `Function` constructor they really expect whatever that symbol returns to be the final verdict whether something should be considered a `function` or not and therefore we shall not worry about those cases.

I also added tests for that and updated the docs.

I will also submit a PR to the main repo later.