### PR TITLE
Replace simple-assert with a throw

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "mocha": "^3.1.2",
     "phantomjs-prebuilt": "^2.1.5",
     "semantic-release": "^4.3.5",
-    "simple-assert": "^1.0.0",
     "travis-after-all": "^1.4.4",
     "validate-commit-msg": "^2.3.1"
   },

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,11 @@
 'use strict';
-var assert = require('simple-assert');
 var getFuncName = require('..');
+function assert(expr, msg) {
+  if (!expr) {
+    throw new Error(msg || 'Assertion Failed');
+  }
+}
+
 describe('getFuncName', function () {
   it('should get the function name', function () {
     function normalFunction() {


### PR DESCRIPTION
I don't think the `simple-assert` package is really needed here. We can reduce our dependencies by writing a pretty simple assert function ourselves.